### PR TITLE
RecordOutputStream#writeRaw emits long instead of void

### DIFF
--- a/dfs-datastores/src/main/java/com/backtype/hadoop/formats/RecordOutputStream.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/formats/RecordOutputStream.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 
 
 public interface RecordOutputStream {
-    public void writeRaw(byte[] record) throws IOException;
-    public void writeRaw(byte[] record, int start, int length) throws IOException;
-    public void close() throws IOException;
-    public void flush() throws IOException;
+    long writeRaw(byte[] record) throws IOException;
+    long writeRaw(byte[] record, int start, int length) throws IOException;
+    void close() throws IOException;
+    void flush() throws IOException;
 }

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/formats/SequenceFileOutputStream.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/formats/SequenceFileOutputStream.java
@@ -10,26 +10,32 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 
 import java.io.IOException;
 
+import static org.apache.hadoop.io.SequenceFile.Writer.file;
+import static org.apache.hadoop.io.SequenceFile.Writer.compression;
+import static org.apache.hadoop.io.SequenceFile.Writer.keyClass;
+import static org.apache.hadoop.io.SequenceFile.Writer.valueClass;
+
 public class SequenceFileOutputStream implements RecordOutputStream {
 
     private SequenceFile.Writer _writer;
     private BytesWritable writable = new BytesWritable();
 
     public SequenceFileOutputStream(FileSystem fs, Path path) throws IOException {
-        _writer = SequenceFile.createWriter(fs, fs.getConf(), path, BytesWritable.class, NullWritable.class, CompressionType.NONE);
+        _writer = SequenceFile.createWriter(fs.getConf(), file(path), keyClass(BytesWritable.class), valueClass(NullWritable.class), compression(CompressionType.NONE));
     }
 
     public SequenceFileOutputStream(FileSystem fs, Path path, CompressionType type, CompressionCodec codec) throws IOException {
-        _writer = SequenceFile.createWriter(fs, fs.getConf(), path, BytesWritable.class, NullWritable.class, type, codec);
+        _writer = SequenceFile.createWriter(fs.getConf(), file(path), keyClass(BytesWritable.class), valueClass(NullWritable.class), compression(type, codec));
     }
 
-    public void writeRaw(byte[] record) throws IOException {
-        writeRaw(record, 0, record.length);
+    public long writeRaw(byte[] record) throws IOException {
+        return writeRaw(record, 0, record.length);
     }
 
-    public void writeRaw(byte[] record, int start, int length) throws IOException {
+    public long writeRaw(byte[] record, int start, int length) throws IOException {
         writable.set(record, start, length);
         _writer.append(writable, NullWritable.get());
+        return _writer.getLength();
     }
 
 

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/formats/SimpleOutputStream.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/formats/SimpleOutputStream.java
@@ -19,13 +19,14 @@ public class SimpleOutputStream implements RecordOutputStream {
         return _raw;
     }
 
-    public void writeRaw(byte[] record) throws IOException {
-        writeRaw(record, 0, record.length);
+    public long writeRaw(byte[] record) throws IOException {
+        return writeRaw(record, 0, record.length);
     }
 
-    public void writeRaw(byte[] record, int start, int length) throws IOException {
+    public long writeRaw(byte[] record, int start, int length) throws IOException {
         _os.writeInt(length);
         _os.write(record, start, length);
+        return _os.size();
     }
 
     public void close() throws IOException {

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/AbstractPail.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/AbstractPail.java
@@ -51,8 +51,8 @@ public abstract class AbstractPail {
             }
         }
 
-        public void writeRaw(byte[] record) throws IOException {
-            writeRaw(record, 0, record.length);
+        public long writeRaw(byte[] record) throws IOException {
+            return writeRaw(record, 0, record.length);
         }
 
         private Function<Object,Boolean> tryRename()
@@ -84,8 +84,8 @@ public abstract class AbstractPail {
             // NOT DOING ANYTHING TO LEAVE IT AT STATUS-QUO
         }
 
-        public void writeRaw(byte[] record, int start, int length) throws IOException {
-            delegate.writeRaw(record, start, length);
+        public long writeRaw(byte[] record, int start, int length) throws IOException {
+            return delegate.writeRaw(record, start, length);
         }
     }
 
@@ -121,8 +121,8 @@ public abstract class AbstractPail {
             delegate = createOutputStream(finalFile);
         }
 
-        public void writeRaw(byte[] record) throws IOException {
-            writeRaw(record, 0, record.length);
+        public long writeRaw(byte[] record) throws IOException {
+            return writeRaw(record, 0, record.length);
         }
 
         public void close() throws IOException {
@@ -134,8 +134,8 @@ public abstract class AbstractPail {
             // NOT DOING ANYTHING TO LEAVE IT AT STATUS-QUO
         }
 
-        public void writeRaw(byte[] record, int start, int length) throws IOException {
-            delegate.writeRaw(record, start, length);
+        public long writeRaw(byte[] record, int start, int length) throws IOException {
+            return delegate.writeRaw(record, start, length);
         }
     }
 

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
@@ -35,7 +35,7 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
             _workers = new HashMap<String, RecordOutputStream>();
         }
 
-        public <T> void writeObject(T obj) throws IOException {
+        public <T> long writeObject(T obj) throws IOException {
             PailStructure<T> structure = ((PailStructure<T>) _structure);
             List<String> rootAttrs = structure.getTarget(obj);
             List<String> attrs = makeRelative(rootAttrs);
@@ -52,13 +52,7 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
                 _workers.put(targetDir, Pail.super.openWrite(p.toString(), _overwrite));
             }
             RecordOutputStream os = _workers.get(targetDir);
-            os.writeRaw(structure.serialize(obj));
-        }
-
-        public void writeObjects(T... objs) throws IOException {
-            for(T obj: objs) {
-                writeObject(obj);
-            }
+            return os.writeRaw(structure.serialize(obj));
         }
 
         public void close() throws IOException {
@@ -81,16 +75,16 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
             return Utils.stripRoot(getAttrs(), attrs);
         }
 
-        public void writeRaw(byte[] record) throws IOException {
-            writeRaw(record, 0, record.length);
+        public long writeRaw(byte[] record) throws IOException {
+            return writeRaw(record, 0, record.length);
         }
 
-        public void writeRaw(byte[] record, int start, int length) throws IOException {
+        public long writeRaw(byte[] record, int start, int length) throws IOException {
             if(!_workers.containsKey(_userfilename)) {
                 checkValidStructure(_userfilename);
                 _workers.put(_userfilename, Pail.super.openWrite(_userfilename, _overwrite));
             }
-            _workers.get(_userfilename).writeRaw(record, start, length);
+            return _workers.get(_userfilename).writeRaw(record, start, length);
         }
     }
 


### PR DESCRIPTION
The underlying implementation of SequenceFileWriter returns current offset of the file that's been written. This might be useful for us to index the records as and when we write them using Pail's writer.

cc: @brewkode 